### PR TITLE
Fix https://github.com/InsightSoftwareConsortium/itk-wasm/issues/1141

### DIFF
--- a/packages/image-io/typescript/src/image-io-index.ts
+++ b/packages/image-io/typescript/src/image-io-index.ts
@@ -54,7 +54,7 @@ const imageIoIndex = new Map([
   ['vtk', [vtkReadImage, vtkWriteImage]],
   ['bmp', [bmpReadImage, bmpWriteImage]],
   ['hdf5', [hdf5ReadImage, hdf5WriteImage]],
-  ['minc', [mincReadImage, mincWriteImage]],
+  ['mnc', [mincReadImage, mincWriteImage]],
   ['mrc', [mrcReadImage, mrcWriteImage]],
   ['lsm', [lsmReadImage, lsmWriteImage]],
   ['mgh', [mghReadImage, mghWriteImage]],


### PR DESCRIPTION
Fix https://github.com/InsightSoftwareConsortium/itk-wasm/issues/1141 by renaming the MINC ImageIO from `minc` to `mnc` to be consistent with `extension-to-image-io.js`